### PR TITLE
Add Trust Wallet to the list of wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Contributors: Phil Kurtland (Scanate), Robert Hackett (Fortune Magazine), Jorge 
 - [Harmony Wallet](https://github.com/ether-camp/ethereum-harmony/releases/latest)
 - [imToken](https://token.im/)
 - [Toshi Wallet + Dapp Browser + Messenger](https://toshi.org)
+- [Trust Wallet + Dapp Browser](https://trustwalletapp.com)
 
 #### Hardware Wallets
 - [Ledger Nano S](https://theethereum.wiki/w/index.php/Ledger_Nano_S)


### PR DESCRIPTION
Yo!!!

Happy to add Trust Wallet! Open Source Ethereum Wallet and DApp Browser:
https://github.com/TrustWallet

Official website: https://trustwalletapp.com